### PR TITLE
Fix timer note in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,5 +85,5 @@ Speichert einen neuen Zeiteintrag.
 
 ## Sonstiges
 
-- Timer kabb erst nach Eingabe eines Tasknamens gestartet werden
+- Timer kann erst nach Eingabe eines Tasknamens gestartet werden
 - Die Duration rundet jede angefangene Minute auf


### PR DESCRIPTION
## Summary
- correct a typo about the timer requirement in the README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68407e966148832c9a01731bef9fb0b1